### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# Description
+Issue # (add the issue number here, if applicable)
+
+Describe what you're adding
+
+# QA
+List out how to test your changes and add a screenshot of what it should look like, when applicable.


### PR DESCRIPTION
# Description
Adding a basic template so our PRs are consistent. I followed [these instructions.](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) 

# QA
When reviewing the `.github/pull_request_template.md` click on the file icon on the top right to see the rich diff. That should give you an idea of what the new default template will look like.